### PR TITLE
Integrate AtlasOCR Model into KITAB-Bench OCR Evaluation Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ python3 metric.py --model_name easyocr # get mAP and CER scores
 ```
 
 ### **6️⃣ OCR Evaluation**
-Available models are EasyOCR, Surya, Tesseract, Gemini-2.0-Flash, GPT-4o, GPT-4o-mini, Qwen2-VL, Qwen2.5-VL, and PaddleOCR. 
+Available models are EasyOCR, Surya, Tesseract, Gemini-2.0-Flash, GPT-4o, GPT-4o-mini, Qwen2-VL, Qwen2.5-VL, AtlasOCR, and PaddleOCR. 
 ```bash
 cd ocr-eval
 pip3 install -r requirements.txt

--- a/ocr-eval/eval.py
+++ b/ocr-eval/eval.py
@@ -3,7 +3,7 @@ import os
 from tqdm import tqdm
 import json
 import datasets
-from models import EasyOCR, GeminiOCR, PaddleGPUOCR, SuryaOCR, TesseractOCR, GPT4oOCR, Qwen2VLOCR, Qwen25VLOCR, ArabicNougat, SmolDocling, QaariOCR, AzureOCR, AVAILABLE_MODELS
+from models import EasyOCR, GeminiOCR, PaddleGPUOCR, SuryaOCR, TesseractOCR, GPT4oOCR, Qwen2VLOCR, Qwen25VLOCR, ArabicNougat, SmolDocling, QaariOCR, AzureOCR, AtlasOCR, AVAILABLE_MODELS
 
 DEFAULT_PROMPT = "Extract the text in the image. Give me the final text, nothing else."
 RESULTS_DIR = "results"
@@ -58,6 +58,8 @@ def get_model(model_name: str, flash_attn: bool):
         return QaariOCR(max_tokens=MAX_TOKENS, use_flash_attn=flash_attn)
     if model_name == "azure": 
         return AzureOCR()
+    if model_name == "atlasocr":
+        return AtlasOCR()
     raise ValueError(f"Model {model_name} not found")
 
 

--- a/ocr-eval/eval.py
+++ b/ocr-eval/eval.py
@@ -59,7 +59,7 @@ def get_model(model_name: str, flash_attn: bool):
     if model_name == "azure": 
         return AzureOCR()
     if model_name == "atlasocr":
-        return AtlasOCR()
+        return AtlasOCR(max_tokens=MAX_TOKENS)
     raise ValueError(f"Model {model_name} not found")
 
 

--- a/ocr-eval/models/__init__.py
+++ b/ocr-eval/models/__init__.py
@@ -10,5 +10,6 @@ from .arabicnougat_model import ArabicNougat
 from .smoldocling_model import SmolDocling
 from .qaari_model import QaariOCR
 from .azure_model import AzureOCR
+from .atlasocr_model import AtlasOCR
 
-AVAILABLE_MODELS = ["easyocr", "gemini", "paddle", "surya", "tesseract", "gpt-4o", "gpt-4o-mini", "qwen2vl", "qwen25vl", "arabicnougat_small", "arabicnougat_base", "arabicnougat_large", "smoldocling", "qaari", "azure"]
+AVAILABLE_MODELS = ["easyocr", "gemini", "paddle", "surya", "tesseract", "gpt-4o", "gpt-4o-mini", "qwen2vl", "qwen25vl", "arabicnougat_small", "arabicnougat_base", "arabicnougat_large", "smoldocling", "qaari", "azure","atlasocr"]

--- a/ocr-eval/models/atlasocr_model.py
+++ b/ocr-eval/models/atlasocr_model.py
@@ -40,7 +40,7 @@ class AtlasOCR:
         return inputs
     
     def predict(self,image:Image) -> str:
-        inputs = self.prepare_inputs(image, self.processor)
+        inputs = self.prepare_inputs(image)
         inputs = inputs.to("cuda")
 
         inputs['attention_mask'] = inputs['attention_mask'].to(torch.float32)

--- a/ocr-eval/models/atlasocr_model.py
+++ b/ocr-eval/models/atlasocr_model.py
@@ -1,0 +1,60 @@
+import os
+from PIL import Image
+from unsloth import FastVisionModel
+import torch
+
+class AtlasOCR:
+    def __init__(self, model_name: str="atlasia/AtlasOCR-v0", max_tokens: int=2000):
+        self.model, self.processor = FastVisionModel.from_pretrained(
+            model_name,
+            device_map="auto",
+            load_in_4bit=True,
+            use_gradient_checkpointing="unsloth"
+        )
+        self.max_tokens = max_tokens
+        self.prompt = ""
+    
+    def prepare_inputs(self,image:Image):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                    },
+                    {"type": "text", "text": self.prompt},
+                ],
+            }
+        ]
+
+        text = self.processor.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+
+        inputs = self.processor(
+            image,
+            text,
+            add_special_tokens=False,
+            return_tensors="pt",
+        )
+        return inputs
+    
+    def predict(self,image:Image) -> str:
+        inputs = self.prepare_inputs(image, self.processor)
+        inputs = inputs.to("cuda")
+
+        inputs['attention_mask'] = inputs['attention_mask'].to(torch.float32)
+        print("attention_mask dtype:", inputs['attention_mask'].dtype)
+
+        generated_ids = self.model.generate(**inputs, max_new_tokens=self.max_tokens, use_cache=True)
+        generated_ids_trimmed = [
+            out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+        ]
+        output_text = self.processor.batch_decode(
+            generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+        )
+        return output_text[0]
+
+    def __call__(self, _: str, image: Image) -> str:
+        return self.predict(image)
+        

--- a/ocr-eval/requirements.txt
+++ b/ocr-eval/requirements.txt
@@ -14,3 +14,4 @@ torch==2.6.0
 torchvision==0.21.0
 transformers==4.49.0
 regex==2024.11.6
+unsloth


### PR DESCRIPTION
* **AtlasOCR Class Implementation:** A new class AtlasOCR has been added under ocr-eval/models/ to encapsulate the model loading, input preparation, and prediction logic for the AtlasOCR model. 
* **eval.py Integration (ocr-eval/eval.py):**
  - **Import AtlasOCR:** The AtlasOCR model is now imported from the models module.
  - **get_model Function Update:** The get_model function now includes a condition to return an instance of AtlasOCR when model_name is "atlasocr". 
  - **AVAILABLE_MODELS Update:** (Implicitly, assuming AVAILABLE_MODELS is updated in init_.py to include "atlasocr".) This allows the atlasocr model to be selected via command-line arguments for evaluation.

This integration allows us to leverage the AtlasOCR model for improved OCR accuracy and performance within the KITAB-Bench framework and enables its evaluation alongside other OCR models.